### PR TITLE
Regex Wrapper 코드 별도 분리 및 타 Validator 구조 수정

### DIFF
--- a/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessageStatusQueryValidator.cs
@@ -45,10 +45,10 @@ namespace Toast.Sms.Validators
         /// <summary>
         /// Initializes a new instance of the <see cref="ListMessageStatusRequestQueryValidator"/> class.
         /// </summary>
-        public ListMessageStatusRequestQueryValidator()
+        public ListMessageStatusRequestQueryValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
         {
-            this.RuleFor(p => p.StartUpdateDate).Must(IsValidDateFormat).NotEmpty();
-            this.RuleFor(p => p.EndUpdateDate).Must(IsValidDateFormat).NotEmpty().GreaterThan(q => q.StartUpdateDate);
+            this.RuleFor(p => p.StartUpdateDate).Must(iRegexDateTimeWrapper.IsMatch).NotEmpty();
+            this.RuleFor(p => p.EndUpdateDate).Must(iRegexDateTimeWrapper.IsMatch).NotEmpty().GreaterThan(q => q.StartUpdateDate);
             When(p => p.MessageType != null, () =>
             {
                 this.RuleFor(p => p.MessageType).Must(p => MsgType.Contains(p));
@@ -58,17 +58,5 @@ namespace Toast.Sms.Validators
 
         }
         List<string> MsgType = new List<string>() { "SMS", "LMS", "MMS", "AUTH" };
-
-        private bool IsValidDateFormat(string date)
-        {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
-            }   
-        }
     }
 }

--- a/src/nt-sms/Validators/ListMessagesQueryValidator.cs
+++ b/src/nt-sms/Validators/ListMessagesQueryValidator.cs
@@ -37,27 +37,6 @@ namespace Toast.Sms.Validators
         }
     }
 
-    public interface IRegexDateTimeWrapper
-    {
-        bool IsMatch(string date);
-    }
-
-    public class RegexDateTimeWrapper : IRegexDateTimeWrapper
-    {
-        private static Regex regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
-
-        public bool IsMatch(string date)
-        {
-            if (date == null)
-            {
-                return false;
-            }
-            else
-            {
-                return regex.IsMatch(date);
-            }
-        }
-    }
     public class ListMessagesRequestQueryValidator : AbstractValidator<ListMessagesRequestQueries>
     {
         /// <summary>
@@ -129,8 +108,6 @@ namespace Toast.Sms.Validators
 
             this.RuleFor(p => p.PageSize).GreaterThan(0);
         }
-
-
 
         List<string> MsgStatusType = new List<string>() { "0", "1", "2", "3", "4", "5" };
         List<string> resultCodeType = new List<string>() { "MTR1", "MTR2" };

--- a/src/nt-sms/Validators/RegexDateTimeWrapper.cs
+++ b/src/nt-sms/Validators/RegexDateTimeWrapper.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+
+namespace Toast.Sms.Validators
+{
+    /// <summary>
+    /// This represents the singleton entity of regex for the validators.
+    /// </summary>
+    public interface IRegexDateTimeWrapper
+    {
+        bool IsMatch(string date);
+    }
+
+    public class RegexDateTimeWrapper : IRegexDateTimeWrapper
+    {
+        private static Regex _regex = new Regex(@"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
+
+        public bool IsMatch(string date)
+        {
+            if (date == null)
+            {
+                return false;
+            }
+            else
+            {
+                return _regex.IsMatch(date);
+            }
+        }
+    }
+}

--- a/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
+++ b/src/nt-sms/Validators/SendMessagesRequestBodyValidator.cs
@@ -42,21 +42,16 @@ namespace Toast.Sms.Validators
         /// Initializes a new instance of the <see cref="SendMessagesRequestBodyValidator"/> class.
         /// </summary>
         ///
-        public SendMessagesRequestBodyValidator()
+        public SendMessagesRequestBodyValidator(IRegexDateTimeWrapper iRegexDateTimeWrapper)
         {
             this.RuleFor(p => p.TemplateId).MaximumLength(50).When(p => p.TemplateId != null);
             this.RuleFor(p => p.Body).NotNull().MaximumLength(255);
             this.RuleFor(p => p.SenderNumber).NotEmpty().MaximumLength(13);
-            this.RuleFor(p => p.RequestDate).Must(IsValidDateFormat).When(p => !string.IsNullOrWhiteSpace(p.RequestDate));
+            this.RuleFor(p => p.RequestDate).Must(iRegexDateTimeWrapper.IsMatch).When(p => !string.IsNullOrWhiteSpace(p.RequestDate));
             this.RuleFor(p => p.SenderGroupingKey).MaximumLength(100);
             this.RuleForEach(p => p.Recipients).SetValidator(new SendMessagesRequestRecipientValidator());
             this.RuleFor(p => p.UserId).MaximumLength(100).When(p => p.UserId != null);
             this.RuleFor(p => p.StatsId).MaximumLength(100).When(p => p.StatsId != null);
-        }
-
-        private bool IsValidDateFormat(string date)
-        {
-            return Regex.IsMatch(date, @"^([0-9][0-9][0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1]) ([01][0-9]|2[0123]):([0-5][0-9]):([0-5][0-9])$");
         }
     }
     /// <summary>

--- a/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/ListMessageStatusRequestQueryValidatorTests.cs
@@ -35,7 +35,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            var validator = new ListMessageStatusRequestQueryValidator();
+            
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = validator.Validate(queries);
 
@@ -62,7 +64,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            var validator = new ListMessageStatusRequestQueryValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
 
             Func<Task> func = async () => await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 
@@ -84,7 +88,9 @@ namespace Toast.Sms.Tests.Validators
                 PageNumber = pageNumber,
                 PageSize = pageSize
             };
-            var validator = new ListMessageStatusRequestQueryValidator();
+            
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new ListMessageStatusRequestQueryValidator(iRegexDateTimeWrapper);
 
             var result = await ListMessageStatusRequestQueryValidatorExtension.Validate(Task.FromResult(queries), validator).ConfigureAwait(false);
 

--- a/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
+++ b/test/NhnToast.Sms.Tests/Validators/SendMessagesRequestBodyValidatorTests.cs
@@ -48,7 +48,9 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-            var validator = new SendMessagesRequestBodyValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
 
             var result = validator.Validate(payloads);
 
@@ -88,7 +90,9 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-            var validator = new SendMessagesRequestBodyValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
 
             Func<Task> func = async () => await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 
@@ -126,7 +130,9 @@ namespace Toast.Sms.Tests.Validators
                 UserId = userId,
                 StatsId = statsId
             };
-            var validator = new SendMessagesRequestBodyValidator();
+
+            IRegexDateTimeWrapper iRegexDateTimeWrapper = new RegexDateTimeWrapper();
+            var validator = new SendMessagesRequestBodyValidator(iRegexDateTimeWrapper);
 
             var result = await SendMessagesRequestBodyValidatorExtension.Validate(Task.FromResult(payloads), validator).ConfigureAwait(false);
 


### PR DESCRIPTION
RegexDateTimeWrapper 클래스 및 인터페이스를 개별 코드로 분리하고, SendMessagesRequestBodyValidator와 ListMessageStatusQueryValidator 코드에 있던 isValidDateFormat 클래스를 RegexDateTimeWrapper 클래스로 대체하였습니다.