### PR TITLE
로컬 에러 수정 - 의존성 주입

### DIFF
--- a/src/nt-sms/Startup.cs
+++ b/src/nt-sms/Startup.cs
@@ -45,6 +45,7 @@ namespace Toast.Sms
 
         private static void ConfigureValidators(IServiceCollection services)
         {
+            services.AddSingleton<IRegexDateTimeWrapper, RegexDateTimeWrapper>();
             services.AddScoped<IValidator<GetMessageRequestQueries>, GetMessageRequestQueryValidator>();
             services.AddScoped<IValidator<ListMessagesRequestQueries>, ListMessagesRequestQueryValidator>();
             services.AddScoped<IValidator<ListMessageStatusRequestQueries>, ListMessageStatusRequestQueryValidator>();


### PR DESCRIPTION
로컬의 엔드포인트에서 Validator에 리퀘스트를 날렸을 때 쓰지 못하는 에러를 수정했습니다.
원인은 서비스에 의존성을 주입하지 않은 거였습니다.